### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Jean-Yves VET
 maintainer=Jean-Yves VET <contact@jean-yves.vet>
 sentence=Driver library for 24xx external (I2C) EEPROMs.
 paragraph=Driver library for 24xx external (I2C) EEPROMs.
+category=Data Storage
 url=https://github.com/jyvet/EEPROM24xx
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category '' in library EEPROM24xx is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format